### PR TITLE
Fix bugs relating to profiles during `test-all`

### DIFF
--- a/external/lein-repo/src/lein_repo/plugin.clj
+++ b/external/lein-repo/src/lein_repo/plugin.clj
@@ -4,7 +4,7 @@
             [clojure.set :as set]
             [clojure.pprint :as pprint]
             [clojure.java.shell :as shell]
-            [leiningen.core.project :as project]
+            [leiningen.core.project :as project])
   (:import [java.io File]
            [java.util HashMap Stack Queue]
            [java.util.jar Manifest JarEntry JarOutputStream]))

--- a/external/lein-repo/src/lein_repo/plugin.clj
+++ b/external/lein-repo/src/lein_repo/plugin.clj
@@ -124,13 +124,13 @@
    :repositories merge
    :plugins concat-distinct
    :repl-options (fn [p1 p2] (merge-with concat-distinct p1 p2))
+   :jvm-opts concat-distinct
    :profiles (fn [p1 p2]
                (merge-with merge-projects p1 p2))
 
    ;; cljx specific
    :prep-tasks concat-distinct
-   :cljx (fn [a b] {:builds (concat-distinct (:builds a) (:builds b))})
-   :jvm-opts concat-distinct})
+   :cljx (fn [a b] {:builds (concat-distinct (:builds a) (:builds b))})})
 
 (defn fix-cljx
   "Cljx paths are not properly normalized like other source paths; manually ensure they are
@@ -231,8 +231,8 @@
 (defn merge-test-profile
   "Can't figure out how to make the task respect the :test profile, so
   just merge the :test profile map into the project"
-  [megatask]
-  (merge-projects-without-normalize megatask (get-in megatask [:profiles :test])))
+  [megaproject]
+  (merge-projects-without-normalize megaproject (get-in megaproject [:profiles :test])))
 
 (defn test-all-project* [base]
   (let [internal-deps (all-internal-deps)

--- a/external/lein-repo/src/leiningen/test_all.clj
+++ b/external/lein-repo/src/leiningen/test_all.clj
@@ -6,13 +6,13 @@
             [leiningen.core.classpath :as classpath]))
 
 (defn test-all [project & [option]]
-  (let [mega-project @plugin/test-all-project
+  (let [mega-project (plugin/test-all-project project)
         summary (eval/eval-in-project
                  mega-project
                  `(do
                     #_(plumbing.error/init-logger! :fatal)
                     (let [summary# (lein-repo.test/test-dirs
-                                    ~(vec (plugin/ordered-source-and-test-paths))
+                                    ~(vec (plugin/ordered-source-and-test-paths project))
                                     :test-selector ~(keyword (or option "fast")))]
                       (println summary#)
                       (System/exit (+ (:error summary# 0) (:fail summary# 0)))))


### PR DESCRIPTION
- :jvm-opts within :profiles were not being properly merged into the
  original project
- test-all was not respecting :test profile
